### PR TITLE
remove required flag for aws creds - let aws-sdk use iam instance profile

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -1,8 +1,8 @@
 actions :create, :update, :delete
 default_action :create
 
-attribute :aws_access_key, kind_of: String, required: true
-attribute :aws_secret_access_key, kind_of: String, required: true
+attribute :aws_access_key, kind_of: String
+attribute :aws_secret_access_key, kind_of: String
 attribute :region, kind_of: String, required: true
 attribute :cache_cluster_id, kind_of: String, name_attribute: true
 attribute :num_cache_nodes, kind_of: Integer, required: true


### PR DESCRIPTION
No need to require aws keys in resource. The aws-sdk gem will source them from the IAM instance profile if not provided. Requiring them at the resource level prohibits the use of IAM instance profiles which are a best practice. Thanks.
