### PR TITLE
Fixes new aws sdk ver issues

### DIFF
--- a/libraries/aws_elasticache.rb
+++ b/libraries/aws_elasticache.rb
@@ -16,6 +16,7 @@ module NDAwsLibs
 
       def ec_connection(key = new_resource.aws_access_key, secret = new_resource.aws_secret_access_key, region = new_resource.region)
         begin
+          gem 'aws-sdk-core', '=2.0.18'
           require "aws-sdk-core"
         rescue LoadError
           Chef::Log.error("Missing gem aws-sdk-core.  Apply aws-elasticache::default to install it.")

--- a/libraries/aws_elasticache.rb
+++ b/libraries/aws_elasticache.rb
@@ -16,12 +16,11 @@ module NDAwsLibs
 
       def ec_connection(key = new_resource.aws_access_key, secret = new_resource.aws_secret_access_key, region = new_resource.region)
         begin
-          gem 'aws-sdk-core', '=2.0.18'
           require "aws-sdk-core"
         rescue LoadError
           Chef::Log.error("Missing gem aws-sdk-core.  Apply aws-elasticache::default to install it.")
         end
-        @ec_conn ||= Aws::ElastiCache.new(access_key_id: key, secret_access_key: secret)
+        @ec_conn ||= Aws::ElastiCache::Client.new(access_key_id: key, secret_access_key: secret)
       end
 
       def cluster_exists?(cluster_id)

--- a/libraries/aws_elasticache.rb
+++ b/libraries/aws_elasticache.rb
@@ -20,7 +20,7 @@ module NDAwsLibs
         rescue LoadError
           Chef::Log.error("Missing gem aws-sdk-core.  Apply aws-elasticache::default to install it.")
         end
-        @ec_conn ||= Aws::ElastiCache::Client.new(access_key_id: key, secret_access_key: secret)
+        @ec_conn ||= Aws::ElastiCache::Client.new(access_key_id: key, secret_access_key: secret, region: region)
       end
 
       def cluster_exists?(cluster_id)

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -1,8 +1,8 @@
 actions :create, :update, :delete
 default_action :create
 
-attribute :aws_access_key, kind_of: String, required: true
-attribute :aws_secret_access_key, kind_of: String, required: true
+attribute :aws_access_key, kind_of: String
+attribute :aws_secret_access_key, kind_of: String
 attribute :region, kind_of: String, required: true
 attribute :cache_cluster_id, kind_of: String, name_attribute: true
 attribute :num_cache_nodes, kind_of: Integer, required: true


### PR DESCRIPTION
The library needs to use the newer constructor class to create the elasticache instance, or else you will get an undefined method `new' on Chef::Resource::ElbLoadBalancer.
Docs for the class can be found here:

http://docs.aws.amazon.com/sdkforruby/api/Aws/ElastiCache/Client.html

Also, there is no reason to set the aws key resource attributes as required, as this prohibits the use of IAM profiles to retrieve temporary credentials.

Please merge, and just let me know if you have any questions or concerns. Thanks.
